### PR TITLE
Schedulers.newThread() to Schedulers.io()

### DIFF
--- a/app/src/main/java/com/example/android_kotlin_handson/api/RetrofitSearchRepositoryApi.java
+++ b/app/src/main/java/com/example/android_kotlin_handson/api/RetrofitSearchRepositoryApi.java
@@ -33,7 +33,7 @@ public class RetrofitSearchRepositoryApi implements SearchRepositoryApi {
     public Single<List<Repository>> searchRepositoryByLanguage(String language) {
         String query = "language:" + language;
         return service.searchRepositoryByLanguage(query)
-                .subscribeOn(Schedulers.newThread())
+                .subscribeOn(Schedulers.io())
                 .map(this::convertToModel);
     }
 


### PR DESCRIPTION
`Schedulers.newThread()` だとsubscribeする度にスレッドが立ち上がるので `Schedulers.io()` がよいと思いました